### PR TITLE
utf8 mappings should not spill over to other buffers

### DIFF
--- a/agda-utf8.vim
+++ b/agda-utf8.vim
@@ -1,827 +1,827 @@
 " Combining marks
-imap <LocalLeader>over`  ̀
-imap <LocalLeader>over'  ́
-imap <LocalLeader>over^  ̂
-imap <LocalLeader>overv  ̌
-imap <LocalLeader>over~  ̃
-imap <LocalLeader>over-  ̄
-imap <LocalLeader>over_  ̅
-imap <LocalLeader>over–  ̅
-imap <LocalLeader>over—  ̅
-imap <LocalLeader>overcup  ̆
-imap <LocalLeader>overcap  ̑
-imap <LocalLeader>over.  ̇
-imap <LocalLeader>over..  ̈
-imap <LocalLeader>over"  ̈
-imap <LocalLeader>over...  ⃛
-imap <LocalLeader>overright.  ͘
-imap <LocalLeader>overo  ̊
-imap <LocalLeader>over``  ̏
-imap <LocalLeader>over''  ̋
-imap <LocalLeader>overvec  ⃑
-imap <LocalLeader>vec  ⃑
-imap <LocalLeader>overlvec  ⃐
-imap <LocalLeader>lvec  ⃐
-imap <LocalLeader>overarc  ⃕
-imap <LocalLeader>overlarc  ⃔
-imap <LocalLeader>overto  ⃗
-imap <LocalLeader>overfrom  ⃖
-imap <LocalLeader>overfromto  ⃡
-imap <LocalLeader>over*  ⃰
-imap <LocalLeader>under`  ̖
-imap <LocalLeader>under'  ̗
-imap <LocalLeader>under,  ̗
-imap <LocalLeader>under.  ̣
-imap <LocalLeader>under..  ̤
-imap <LocalLeader>under"  ̤
-imap <LocalLeader>undero  ̥
-imap <LocalLeader>under-  ̱
-imap <LocalLeader>under_  ̲
-imap <LocalLeader>under–  ̲
-imap <LocalLeader>under—  ̲
-imap <LocalLeader>through~  ̴
-imap <LocalLeader>through-  ̵
-imap <LocalLeader>through_  ̶
-imap <LocalLeader>through–  ̶
-imap <LocalLeader>through—  ̶
-imap <LocalLeader>through/  ̷
-imap <LocalLeader>not  ̷
-imap <LocalLeader>through?  ̸
-imap <LocalLeader>Not  ̸
-imap <LocalLeader>through\|  ⃒
-imap <LocalLeader>throughshortmid  ⃓
-imap <LocalLeader>througho  ⃘
+imap <buffer> <LocalLeader>over`  ̀
+imap <buffer> <LocalLeader>over'  ́
+imap <buffer> <LocalLeader>over^  ̂
+imap <buffer> <LocalLeader>overv  ̌
+imap <buffer> <LocalLeader>over~  ̃
+imap <buffer> <LocalLeader>over-  ̄
+imap <buffer> <LocalLeader>over_  ̅
+imap <buffer> <LocalLeader>over–  ̅
+imap <buffer> <LocalLeader>over—  ̅
+imap <buffer> <LocalLeader>overcup  ̆
+imap <buffer> <LocalLeader>overcap  ̑
+imap <buffer> <LocalLeader>over.  ̇
+imap <buffer> <LocalLeader>over..  ̈
+imap <buffer> <LocalLeader>over"  ̈
+imap <buffer> <LocalLeader>over...  ⃛
+imap <buffer> <LocalLeader>overright.  ͘
+imap <buffer> <LocalLeader>overo  ̊
+imap <buffer> <LocalLeader>over``  ̏
+imap <buffer> <LocalLeader>over''  ̋
+imap <buffer> <LocalLeader>overvec  ⃑
+imap <buffer> <LocalLeader>vec  ⃑
+imap <buffer> <LocalLeader>overlvec  ⃐
+imap <buffer> <LocalLeader>lvec  ⃐
+imap <buffer> <LocalLeader>overarc  ⃕
+imap <buffer> <LocalLeader>overlarc  ⃔
+imap <buffer> <LocalLeader>overto  ⃗
+imap <buffer> <LocalLeader>overfrom  ⃖
+imap <buffer> <LocalLeader>overfromto  ⃡
+imap <buffer> <LocalLeader>over*  ⃰
+imap <buffer> <LocalLeader>under`  ̖
+imap <buffer> <LocalLeader>under'  ̗
+imap <buffer> <LocalLeader>under,  ̗
+imap <buffer> <LocalLeader>under.  ̣
+imap <buffer> <LocalLeader>under..  ̤
+imap <buffer> <LocalLeader>under"  ̤
+imap <buffer> <LocalLeader>undero  ̥
+imap <buffer> <LocalLeader>under-  ̱
+imap <buffer> <LocalLeader>under_  ̲
+imap <buffer> <LocalLeader>under–  ̲
+imap <buffer> <LocalLeader>under—  ̲
+imap <buffer> <LocalLeader>through~  ̴
+imap <buffer> <LocalLeader>through-  ̵
+imap <buffer> <LocalLeader>through_  ̶
+imap <buffer> <LocalLeader>through–  ̶
+imap <buffer> <LocalLeader>through—  ̶
+imap <buffer> <LocalLeader>through/  ̷
+imap <buffer> <LocalLeader>not  ̷
+imap <buffer> <LocalLeader>through?  ̸
+imap <buffer> <LocalLeader>Not  ̸
+imap <buffer> <LocalLeader>through\|  ⃒
+imap <buffer> <LocalLeader>throughshortmid  ⃓
+imap <buffer> <LocalLeader>througho  ⃘
 
 " Math
-imap <LocalLeader>{{ ⦃
-imap <LocalLeader>}} ⦄
-imap <LocalLeader>: ∶
-imap <LocalLeader>:: ∷
-imap <LocalLeader>;  ﹔
-imap <LocalLeader>.. ‥
-imap <LocalLeader>=? ≟
-imap <LocalLeader>all ∀
-imap <LocalLeader>always □
-imap <LocalLeader>approx ≈
-imap <LocalLeader>bot ⊥
-imap <LocalLeader>box □
-imap <LocalLeader>boxdot ⊡
-imap <LocalLeader>box. ⊡
-imap <LocalLeader>boxminus ⊟
-imap <LocalLeader>box- ⊟
-imap <LocalLeader>boxplus ⊞
-imap <LocalLeader>box+ ⊞
-imap <LocalLeader>boxtimes ⊠
-imap <LocalLeader>box* ⊠
-imap <LocalLeader>bul •
-imap <LocalLeader>C ℂ
-imap <LocalLeader>cdot ∙
-imap <LocalLeader>. ∙
-imap <LocalLeader>cdots ⋯
-imap <LocalLeader>check ✓
-imap <LocalLeader>yes ✓
-imap <LocalLeader>Check ✔
-imap <LocalLeader>Yes ✔
-imap <LocalLeader>circ ∘
-imap <LocalLeader>clock ↻
-imap <LocalLeader>cclock ↺
-imap <LocalLeader>comp ∘
-imap <LocalLeader>contra ↯
-imap <LocalLeader>deg °
-imap <LocalLeader>den ⟦⟧<left>
-imap <LocalLeader>diamond ◇
-imap <LocalLeader>dots …
-imap <LocalLeader>down ↓
-imap <LocalLeader>downtri ▼
-imap <LocalLeader>Down ⇓
-imap <LocalLeader>dunion ⊎
-imap <LocalLeader>du ⊎
-imap <LocalLeader>ell ℓ
-imap <LocalLeader>empty ∅
-imap <LocalLeader>equiv ≡
-imap <LocalLeader>eq ≡
-imap <LocalLeader>eventually ◇
-imap <LocalLeader>exists ∃
-imap <LocalLeader>flat ♭
-imap <LocalLeader>fold ⦇⦈<left>
-imap <LocalLeader>(\| ⦇
-imap <LocalLeader>\|) ⦈
-imap <LocalLeader>forall ∀
-imap <LocalLeader>from ←
-imap <LocalLeader><- ←
-imap <LocalLeader>From ⇐
-imap <LocalLeader>fromto ↔
-imap <LocalLeader>Fromto ⇔
-imap <LocalLeader>ge ≥
-imap <LocalLeader>glub ⊓
-imap <LocalLeader>iff ⇔
-imap <LocalLeader>implies ⇒
-imap <LocalLeader>impliedby ⇐
-imap <LocalLeader>in ∈
-imap <LocalLeader>infty ∞
-imap <LocalLeader>inf ∞
-imap <LocalLeader>int ∫
-imap <LocalLeader>intersect ∩
-imap <LocalLeader>iso ≅
-imap <LocalLeader>join ⋈
-imap <LocalLeader>land ∧
-imap <LocalLeader>langle ⟨
-imap <LocalLeader>lbrac ⟦
-imap <LocalLeader>[[ ⟦
-imap <LocalLeader>ldots …
-imap <LocalLeader>ldown ⇃
-imap <LocalLeader>leadsto ⇝
-imap <LocalLeader>~> ⇝
-imap <LocalLeader>le ≤
-imap <LocalLeader>lift ⌊⌋<left>
-imap <LocalLeader>floor ⌊⌋<left>
-imap <LocalLeader>llangle ⟪
-imap <LocalLeader>longto ⟶ 
-imap <LocalLeader>-- ⟶ 
-imap <LocalLeader>– ⟶ 
-imap <LocalLeader>lor ∨
-imap <LocalLeader>lower ⌈⌉<left>
-imap <LocalLeader>ceil ⌈⌉<left>
-imap <LocalLeader>lub ⊔
-imap <LocalLeader>lup ↿
-imap <LocalLeader>mapsto ↦
-imap <LocalLeader>map ↦
-imap <LocalLeader>mid ∣
-imap <LocalLeader>models ⊨
-imap <LocalLeader>\|= ⊨
-imap <LocalLeader>N ℕ
-imap <LocalLeader>ne ≠
-imap <LocalLeader>nearrow ↗
-imap <LocalLeader>Nearrow ⇗
-imap <LocalLeader>neg ¬
-imap <LocalLeader>/= ≠
-imap <LocalLeader>nequiv ≢
-imap <LocalLeader>neq ≢
-imap <LocalLeader>nexist ∄
-imap <LocalLeader>none ∄
-imap <LocalLeader>ni ∋
-imap <LocalLeader>ni ∋
-imap <LocalLeader>nin ∉
-imap <LocalLeader>niso ≇
-imap <LocalLeader>notin ∉
-imap <LocalLeader>nwarrow ↖
-imap <LocalLeader>Nwarrow ⇖
-imap <LocalLeader>oast ⊛
-imap <LocalLeader>odot ⊙
-imap <LocalLeader>o. ⊙
-imap <LocalLeader>of ∘
-imap <LocalLeader>o ∘
-imap <LocalLeader>ominus ⊖
-imap <LocalLeader>o- ⊖
-imap <LocalLeader>oplus ⊕
-imap <LocalLeader>o+ ⊕
-imap <LocalLeader>oslash ⊘
-imap <LocalLeader>o/ ⊘
-imap <LocalLeader>otimes ⊗
-imap <LocalLeader>o* ⊗
-imap <LocalLeader>par ∂
-imap <LocalLeader>pge ≽
-imap <LocalLeader>pgt ≻
-imap <LocalLeader>ple ≼
-imap <LocalLeader>plt ≺
-imap <LocalLeader>p≥ ≽
-imap <LocalLeader>p> ≻
-imap <LocalLeader>p≤ ≼
-imap <LocalLeader>p< ≺
-imap <LocalLeader>pm ±
-imap <LocalLeader>prec ≼
-imap <LocalLeader>prod ∏
-imap <LocalLeader>proves ⊢
-imap <LocalLeader>\|- ⊢
-imap <LocalLeader>provedby ⊣
-imap <LocalLeader>Q ℚ
-imap <LocalLeader>qed ∎
-imap <LocalLeader>R ℝ
-imap <LocalLeader>rangle ⟩
-imap <LocalLeader>rbrac ⟧
-imap <LocalLeader>]] ⟧
-imap <LocalLeader>rdown ⇂
-imap <LocalLeader>righttri ▸
-imap <LocalLeader>rrangle ⟫
-imap <LocalLeader>rup ↾
-imap <LocalLeader>searrow ↘
-imap <LocalLeader>Searrow ⇘
-imap <LocalLeader>setminus ∖
-imap <LocalLeader>sharp ♯
-imap <LocalLeader># ♯
-imap <LocalLeader>sim ∼
-imap <LocalLeader>simeq ≃
-imap <LocalLeader>some ∃
-imap <LocalLeader>sqge ⊒
-imap <LocalLeader>sqgt ⊐
-imap <LocalLeader>sqle ⊑
-imap <LocalLeader>sqlt ⊏
-imap <LocalLeader>s≥ ⊒
-imap <LocalLeader>s> ⊐
-imap <LocalLeader>s≤ ⊑
-imap <LocalLeader>s< ⊏
-imap <LocalLeader>sqr ²
-imap <LocalLeader>sqrt √
-imap <LocalLeader>star ✭
-imap <LocalLeader>subset ⊂
-imap <LocalLeader>sub ⊂
-imap <LocalLeader>subseteq ⊆
-imap <LocalLeader>subeq ⊆
-imap <LocalLeader>subsetneq ⊊
-imap <LocalLeader>subneq ⊊
-imap <LocalLeader>sum ∑
-imap <LocalLeader>supset ⊃
-imap <LocalLeader>sup ⊃
-imap <LocalLeader>supseteq ⊇
-imap <LocalLeader>supeq ⊇
-imap <LocalLeader>supsetneq ⊋
-imap <LocalLeader>supneq ⊋
-imap <LocalLeader>swarrow ↙
-imap <LocalLeader>Swarrow ⇙
-imap <LocalLeader>thus ∴
-imap <LocalLeader>times ×
-imap <LocalLeader>* ×
-imap <LocalLeader>to →
-imap <LocalLeader>- →
-imap <C-_> →
-imap <LocalLeader>To ⇒
-imap <LocalLeader>= ⇒
-imap <LocalLeader>top ⊤
-imap <LocalLeader>tuple ⟨⟩<left>
-imap <LocalLeader>up ↑
-imap <LocalLeader>updown ↕
-imap <LocalLeader>ud ↕
-imap <LocalLeader>unfold ⦉⦊<left>
-imap <LocalLeader><\| ⦉
-imap <LocalLeader>\|> ⦊
-imap <LocalLeader>up;down ⇅
-imap <LocalLeader>u;d ⇅
-imap <LocalLeader>uptri ▲
-imap <LocalLeader>Up ⇑
-imap <LocalLeader>union ∪
-imap <LocalLeader>vdots ⋮
-imap <LocalLeader>voltage ⚡
-imap <LocalLeader>xmark ✗
-imap <LocalLeader>no ✗
-imap <LocalLeader>Xmark ✘
-imap <LocalLeader>No ✘
-imap <LocalLeader>Z ℤ
+imap <buffer> <LocalLeader>{{ ⦃
+imap <buffer> <LocalLeader>}} ⦄
+imap <buffer> <LocalLeader>: ∶
+imap <buffer> <LocalLeader>:: ∷
+imap <buffer> <LocalLeader>;  ﹔
+imap <buffer> <LocalLeader>.. ‥
+imap <buffer> <LocalLeader>=? ≟
+imap <buffer> <LocalLeader>all ∀
+imap <buffer> <LocalLeader>always □
+imap <buffer> <LocalLeader>approx ≈
+imap <buffer> <LocalLeader>bot ⊥
+imap <buffer> <LocalLeader>box □
+imap <buffer> <LocalLeader>boxdot ⊡
+imap <buffer> <LocalLeader>box. ⊡
+imap <buffer> <LocalLeader>boxminus ⊟
+imap <buffer> <LocalLeader>box- ⊟
+imap <buffer> <LocalLeader>boxplus ⊞
+imap <buffer> <LocalLeader>box+ ⊞
+imap <buffer> <LocalLeader>boxtimes ⊠
+imap <buffer> <LocalLeader>box* ⊠
+imap <buffer> <LocalLeader>bul •
+imap <buffer> <LocalLeader>C ℂ
+imap <buffer> <LocalLeader>cdot ∙
+imap <buffer> <LocalLeader>. ∙
+imap <buffer> <LocalLeader>cdots ⋯
+imap <buffer> <LocalLeader>check ✓
+imap <buffer> <LocalLeader>yes ✓
+imap <buffer> <LocalLeader>Check ✔
+imap <buffer> <LocalLeader>Yes ✔
+imap <buffer> <LocalLeader>circ ∘
+imap <buffer> <LocalLeader>clock ↻
+imap <buffer> <LocalLeader>cclock ↺
+imap <buffer> <LocalLeader>comp ∘
+imap <buffer> <LocalLeader>contra ↯
+imap <buffer> <LocalLeader>deg °
+imap <buffer> <LocalLeader>den ⟦⟧<left>
+imap <buffer> <LocalLeader>diamond ◇
+imap <buffer> <LocalLeader>dots …
+imap <buffer> <LocalLeader>down ↓
+imap <buffer> <LocalLeader>downtri ▼
+imap <buffer> <LocalLeader>Down ⇓
+imap <buffer> <LocalLeader>dunion ⊎
+imap <buffer> <LocalLeader>du ⊎
+imap <buffer> <LocalLeader>ell ℓ
+imap <buffer> <LocalLeader>empty ∅
+imap <buffer> <LocalLeader>equiv ≡
+imap <buffer> <LocalLeader>eq ≡
+imap <buffer> <LocalLeader>eventually ◇
+imap <buffer> <LocalLeader>exists ∃
+imap <buffer> <LocalLeader>flat ♭
+imap <buffer> <LocalLeader>fold ⦇⦈<left>
+imap <buffer> <LocalLeader>(\| ⦇
+imap <buffer> <LocalLeader>\|) ⦈
+imap <buffer> <LocalLeader>forall ∀
+imap <buffer> <LocalLeader>from ←
+imap <buffer> <LocalLeader><- ←
+imap <buffer> <LocalLeader>From ⇐
+imap <buffer> <LocalLeader>fromto ↔
+imap <buffer> <LocalLeader>Fromto ⇔
+imap <buffer> <LocalLeader>ge ≥
+imap <buffer> <LocalLeader>glub ⊓
+imap <buffer> <LocalLeader>iff ⇔
+imap <buffer> <LocalLeader>implies ⇒
+imap <buffer> <LocalLeader>impliedby ⇐
+imap <buffer> <LocalLeader>in ∈
+imap <buffer> <LocalLeader>infty ∞
+imap <buffer> <LocalLeader>inf ∞
+imap <buffer> <LocalLeader>int ∫
+imap <buffer> <LocalLeader>intersect ∩
+imap <buffer> <LocalLeader>iso ≅
+imap <buffer> <LocalLeader>join ⋈
+imap <buffer> <LocalLeader>land ∧
+imap <buffer> <LocalLeader>langle ⟨
+imap <buffer> <LocalLeader>lbrac ⟦
+imap <buffer> <LocalLeader>[[ ⟦
+imap <buffer> <LocalLeader>ldots …
+imap <buffer> <LocalLeader>ldown ⇃
+imap <buffer> <LocalLeader>leadsto ⇝
+imap <buffer> <LocalLeader>~> ⇝
+imap <buffer> <LocalLeader>le ≤
+imap <buffer> <LocalLeader>lift ⌊⌋<left>
+imap <buffer> <LocalLeader>floor ⌊⌋<left>
+imap <buffer> <LocalLeader>llangle ⟪
+imap <buffer> <LocalLeader>longto ⟶ 
+imap <buffer> <LocalLeader>-- ⟶ 
+imap <buffer> <LocalLeader>– ⟶ 
+imap <buffer> <LocalLeader>lor ∨
+imap <buffer> <LocalLeader>lower ⌈⌉<left>
+imap <buffer> <LocalLeader>ceil ⌈⌉<left>
+imap <buffer> <LocalLeader>lub ⊔
+imap <buffer> <LocalLeader>lup ↿
+imap <buffer> <LocalLeader>mapsto ↦
+imap <buffer> <LocalLeader>map ↦
+imap <buffer> <LocalLeader>mid ∣
+imap <buffer> <LocalLeader>models ⊨
+imap <buffer> <LocalLeader>\|= ⊨
+imap <buffer> <LocalLeader>N ℕ
+imap <buffer> <LocalLeader>ne ≠
+imap <buffer> <LocalLeader>nearrow ↗
+imap <buffer> <LocalLeader>Nearrow ⇗
+imap <buffer> <LocalLeader>neg ¬
+imap <buffer> <LocalLeader>/= ≠
+imap <buffer> <LocalLeader>nequiv ≢
+imap <buffer> <LocalLeader>neq ≢
+imap <buffer> <LocalLeader>nexist ∄
+imap <buffer> <LocalLeader>none ∄
+imap <buffer> <LocalLeader>ni ∋
+imap <buffer> <LocalLeader>ni ∋
+imap <buffer> <LocalLeader>nin ∉
+imap <buffer> <LocalLeader>niso ≇
+imap <buffer> <LocalLeader>notin ∉
+imap <buffer> <LocalLeader>nwarrow ↖
+imap <buffer> <LocalLeader>Nwarrow ⇖
+imap <buffer> <LocalLeader>oast ⊛
+imap <buffer> <LocalLeader>odot ⊙
+imap <buffer> <LocalLeader>o. ⊙
+imap <buffer> <LocalLeader>of ∘
+imap <buffer> <LocalLeader>o ∘
+imap <buffer> <LocalLeader>ominus ⊖
+imap <buffer> <LocalLeader>o- ⊖
+imap <buffer> <LocalLeader>oplus ⊕
+imap <buffer> <LocalLeader>o+ ⊕
+imap <buffer> <LocalLeader>oslash ⊘
+imap <buffer> <LocalLeader>o/ ⊘
+imap <buffer> <LocalLeader>otimes ⊗
+imap <buffer> <LocalLeader>o* ⊗
+imap <buffer> <LocalLeader>par ∂
+imap <buffer> <LocalLeader>pge ≽
+imap <buffer> <LocalLeader>pgt ≻
+imap <buffer> <LocalLeader>ple ≼
+imap <buffer> <LocalLeader>plt ≺
+imap <buffer> <LocalLeader>p≥ ≽
+imap <buffer> <LocalLeader>p> ≻
+imap <buffer> <LocalLeader>p≤ ≼
+imap <buffer> <LocalLeader>p< ≺
+imap <buffer> <LocalLeader>pm ±
+imap <buffer> <LocalLeader>prec ≼
+imap <buffer> <LocalLeader>prod ∏
+imap <buffer> <LocalLeader>proves ⊢
+imap <buffer> <LocalLeader>\|- ⊢
+imap <buffer> <LocalLeader>provedby ⊣
+imap <buffer> <LocalLeader>Q ℚ
+imap <buffer> <LocalLeader>qed ∎
+imap <buffer> <LocalLeader>R ℝ
+imap <buffer> <LocalLeader>rangle ⟩
+imap <buffer> <LocalLeader>rbrac ⟧
+imap <buffer> <LocalLeader>]] ⟧
+imap <buffer> <LocalLeader>rdown ⇂
+imap <buffer> <LocalLeader>righttri ▸
+imap <buffer> <LocalLeader>rrangle ⟫
+imap <buffer> <LocalLeader>rup ↾
+imap <buffer> <LocalLeader>searrow ↘
+imap <buffer> <LocalLeader>Searrow ⇘
+imap <buffer> <LocalLeader>setminus ∖
+imap <buffer> <LocalLeader>sharp ♯
+imap <buffer> <LocalLeader># ♯
+imap <buffer> <LocalLeader>sim ∼
+imap <buffer> <LocalLeader>simeq ≃
+imap <buffer> <LocalLeader>some ∃
+imap <buffer> <LocalLeader>sqge ⊒
+imap <buffer> <LocalLeader>sqgt ⊐
+imap <buffer> <LocalLeader>sqle ⊑
+imap <buffer> <LocalLeader>sqlt ⊏
+imap <buffer> <LocalLeader>s≥ ⊒
+imap <buffer> <LocalLeader>s> ⊐
+imap <buffer> <LocalLeader>s≤ ⊑
+imap <buffer> <LocalLeader>s< ⊏
+imap <buffer> <LocalLeader>sqr ²
+imap <buffer> <LocalLeader>sqrt √
+imap <buffer> <LocalLeader>star ✭
+imap <buffer> <LocalLeader>subset ⊂
+imap <buffer> <LocalLeader>sub ⊂
+imap <buffer> <LocalLeader>subseteq ⊆
+imap <buffer> <LocalLeader>subeq ⊆
+imap <buffer> <LocalLeader>subsetneq ⊊
+imap <buffer> <LocalLeader>subneq ⊊
+imap <buffer> <LocalLeader>sum ∑
+imap <buffer> <LocalLeader>supset ⊃
+imap <buffer> <LocalLeader>sup ⊃
+imap <buffer> <LocalLeader>supseteq ⊇
+imap <buffer> <LocalLeader>supeq ⊇
+imap <buffer> <LocalLeader>supsetneq ⊋
+imap <buffer> <LocalLeader>supneq ⊋
+imap <buffer> <LocalLeader>swarrow ↙
+imap <buffer> <LocalLeader>Swarrow ⇙
+imap <buffer> <LocalLeader>thus ∴
+imap <buffer> <LocalLeader>times ×
+imap <buffer> <LocalLeader>* ×
+imap <buffer> <LocalLeader>to →
+imap <buffer> <LocalLeader>- →
+imap <buffer> <C-_> →
+imap <buffer> <LocalLeader>To ⇒
+imap <buffer> <LocalLeader>= ⇒
+imap <buffer> <LocalLeader>top ⊤
+imap <buffer> <LocalLeader>tuple ⟨⟩<left>
+imap <buffer> <LocalLeader>up ↑
+imap <buffer> <LocalLeader>updown ↕
+imap <buffer> <LocalLeader>ud ↕
+imap <buffer> <LocalLeader>unfold ⦉⦊<left>
+imap <buffer> <LocalLeader><\| ⦉
+imap <buffer> <LocalLeader>\|> ⦊
+imap <buffer> <LocalLeader>up;down ⇅
+imap <buffer> <LocalLeader>u;d ⇅
+imap <buffer> <LocalLeader>uptri ▲
+imap <buffer> <LocalLeader>Up ⇑
+imap <buffer> <LocalLeader>union ∪
+imap <buffer> <LocalLeader>vdots ⋮
+imap <buffer> <LocalLeader>voltage ⚡
+imap <buffer> <LocalLeader>xmark ✗
+imap <buffer> <LocalLeader>no ✗
+imap <buffer> <LocalLeader>Xmark ✘
+imap <buffer> <LocalLeader>No ✘
+imap <buffer> <LocalLeader>Z ℤ
 
 " Not math
-imap <LocalLeader>sec §
+imap <buffer> <LocalLeader>sec §
 
 " Superscripts
-imap <LocalLeader>^0 ⁰
-imap <LocalLeader>^1 ¹
-imap <LocalLeader>^2 ²
-imap <LocalLeader>^3 ³
-imap <LocalLeader>^4 ⁴
-imap <LocalLeader>^5 ⁵
-imap <LocalLeader>^6 ⁶
-imap <LocalLeader>^7 ⁷
-imap <LocalLeader>^8 ⁸
-imap <LocalLeader>^9 ⁹
-imap <LocalLeader>^n ⁿ
-imap <LocalLeader>^i ⁱ
-imap <LocalLeader>^+ ⁺
-imap <LocalLeader>^- ⁻
-imap <LocalLeader>' ′
-imap <LocalLeader>'' ″
-imap <LocalLeader>''' ‴
-imap <LocalLeader>'''' ⁗
-imap <LocalLeader>" ″
-imap <LocalLeader>"" ⁗
-imap <LocalLeader>` ‵
-imap <LocalLeader>`` ‶
-imap <LocalLeader>``` ‷
+imap <buffer> <LocalLeader>^0 ⁰
+imap <buffer> <LocalLeader>^1 ¹
+imap <buffer> <LocalLeader>^2 ²
+imap <buffer> <LocalLeader>^3 ³
+imap <buffer> <LocalLeader>^4 ⁴
+imap <buffer> <LocalLeader>^5 ⁵
+imap <buffer> <LocalLeader>^6 ⁶
+imap <buffer> <LocalLeader>^7 ⁷
+imap <buffer> <LocalLeader>^8 ⁸
+imap <buffer> <LocalLeader>^9 ⁹
+imap <buffer> <LocalLeader>^n ⁿ
+imap <buffer> <LocalLeader>^i ⁱ
+imap <buffer> <LocalLeader>^+ ⁺
+imap <buffer> <LocalLeader>^- ⁻
+imap <buffer> <LocalLeader>' ′
+imap <buffer> <LocalLeader>'' ″
+imap <buffer> <LocalLeader>''' ‴
+imap <buffer> <LocalLeader>'''' ⁗
+imap <buffer> <LocalLeader>" ″
+imap <buffer> <LocalLeader>"" ⁗
+imap <buffer> <LocalLeader>` ‵
+imap <buffer> <LocalLeader>`` ‶
+imap <buffer> <LocalLeader>``` ‷
 
 " Subscripts
-imap <LocalLeader>0 ₀
-imap <LocalLeader>1 ₁
-imap <LocalLeader>2 ₂
-imap <LocalLeader>3 ₃
-imap <LocalLeader>4 ₄
-imap <LocalLeader>5 ₅
-imap <LocalLeader>6 ₆
-imap <LocalLeader>7 ₇
-imap <LocalLeader>8 ₈
-imap <LocalLeader>9 ₉
-imap <LocalLeader>_i ᵢ
-imap <LocalLeader>_j ⱼ
-imap <LocalLeader>_+ ₊
-imap <LocalLeader>_- ₋
-imap <LocalLeader>p0 π₀
-imap <LocalLeader>p1 π₁
-imap <LocalLeader>p2 π₂
-imap <LocalLeader>p3 π₃
-imap <LocalLeader>p4 π₄
-imap <LocalLeader>p5 π₅
-imap <LocalLeader>p6 π₆
-imap <LocalLeader>p7 π₇
-imap <LocalLeader>p8 π₈
-imap <LocalLeader>p9 π₉
-imap <LocalLeader>i0 ι₀
-imap <LocalLeader>i1 ι₁
-imap <LocalLeader>i2 ι₂
-imap <LocalLeader>i3 ι₃
-imap <LocalLeader>i4 ι₄
-imap <LocalLeader>i5 ι₅
-imap <LocalLeader>i6 ι₆
-imap <LocalLeader>i7 ι₇
-imap <LocalLeader>i8 ι₈
-imap <LocalLeader>i9 ι₉
+imap <buffer> <LocalLeader>0 ₀
+imap <buffer> <LocalLeader>1 ₁
+imap <buffer> <LocalLeader>2 ₂
+imap <buffer> <LocalLeader>3 ₃
+imap <buffer> <LocalLeader>4 ₄
+imap <buffer> <LocalLeader>5 ₅
+imap <buffer> <LocalLeader>6 ₆
+imap <buffer> <LocalLeader>7 ₇
+imap <buffer> <LocalLeader>8 ₈
+imap <buffer> <LocalLeader>9 ₉
+imap <buffer> <LocalLeader>_i ᵢ
+imap <buffer> <LocalLeader>_j ⱼ
+imap <buffer> <LocalLeader>_+ ₊
+imap <buffer> <LocalLeader>_- ₋
+imap <buffer> <LocalLeader>p0 π₀
+imap <buffer> <LocalLeader>p1 π₁
+imap <buffer> <LocalLeader>p2 π₂
+imap <buffer> <LocalLeader>p3 π₃
+imap <buffer> <LocalLeader>p4 π₄
+imap <buffer> <LocalLeader>p5 π₅
+imap <buffer> <LocalLeader>p6 π₆
+imap <buffer> <LocalLeader>p7 π₇
+imap <buffer> <LocalLeader>p8 π₈
+imap <buffer> <LocalLeader>p9 π₉
+imap <buffer> <LocalLeader>i0 ι₀
+imap <buffer> <LocalLeader>i1 ι₁
+imap <buffer> <LocalLeader>i2 ι₂
+imap <buffer> <LocalLeader>i3 ι₃
+imap <buffer> <LocalLeader>i4 ι₄
+imap <buffer> <LocalLeader>i5 ι₅
+imap <buffer> <LocalLeader>i6 ι₆
+imap <buffer> <LocalLeader>i7 ι₇
+imap <buffer> <LocalLeader>i8 ι₈
+imap <buffer> <LocalLeader>i9 ι₉
 
 " Greek (lower)
-imap <LocalLeader>alpha α
-imap <LocalLeader>a α
-imap <LocalLeader>beta β
-imap <LocalLeader>b β
-imap <LocalLeader>gamma γ
-imap <LocalLeader>g γ
-imap <LocalLeader>delta δ
-imap <LocalLeader>d δ
-imap <LocalLeader>epsilon ε
-imap <LocalLeader>e ε
-imap <LocalLeader>zeta ζ
-imap <LocalLeader>z ζ
-imap <LocalLeader>eta η
-imap <LocalLeader>h η
-imap <LocalLeader>theta θ
-imap <LocalLeader>iota ι
-imap <LocalLeader>i ι
-imap <LocalLeader>kappa κ
-imap <LocalLeader>k κ
-imap <LocalLeader>lambda λ
-imap <LocalLeader>l λ
-imap <LocalLeader>mu μ
-imap <LocalLeader>m μ
-imap <LocalLeader>nu ν
-imap <LocalLeader>n ν
-imap <LocalLeader>xi ξ
-imap <LocalLeader>omicron ο
-imap <LocalLeader>pi π
-imap <LocalLeader>p π
-imap <LocalLeader>rho ρ
-imap <LocalLeader>r ρ
-imap <LocalLeader>sigma σ
-imap <LocalLeader>s σ
-imap <LocalLeader>varsigma ς
-imap <LocalLeader>vars ς
-imap <LocalLeader>tau τ
-imap <LocalLeader>t τ
-imap <LocalLeader>u υ
-imap <LocalLeader>phi φ
-imap <LocalLeader>f φ
-imap <LocalLeader>chi χ
-imap <LocalLeader>x χ
-imap <LocalLeader>psi ψ
-imap <LocalLeader>c ψ
-imap <LocalLeader>omega ω
-imap <LocalLeader>v ω
+imap <buffer> <LocalLeader>alpha α
+imap <buffer> <LocalLeader>a α
+imap <buffer> <LocalLeader>beta β
+imap <buffer> <LocalLeader>b β
+imap <buffer> <LocalLeader>gamma γ
+imap <buffer> <LocalLeader>g γ
+imap <buffer> <LocalLeader>delta δ
+imap <buffer> <LocalLeader>d δ
+imap <buffer> <LocalLeader>epsilon ε
+imap <buffer> <LocalLeader>e ε
+imap <buffer> <LocalLeader>zeta ζ
+imap <buffer> <LocalLeader>z ζ
+imap <buffer> <LocalLeader>eta η
+imap <buffer> <LocalLeader>h η
+imap <buffer> <LocalLeader>theta θ
+imap <buffer> <LocalLeader>iota ι
+imap <buffer> <LocalLeader>i ι
+imap <buffer> <LocalLeader>kappa κ
+imap <buffer> <LocalLeader>k κ
+imap <buffer> <LocalLeader>lambda λ
+imap <buffer> <LocalLeader>l λ
+imap <buffer> <LocalLeader>mu μ
+imap <buffer> <LocalLeader>m μ
+imap <buffer> <LocalLeader>nu ν
+imap <buffer> <LocalLeader>n ν
+imap <buffer> <LocalLeader>xi ξ
+imap <buffer> <LocalLeader>omicron ο
+imap <buffer> <LocalLeader>pi π
+imap <buffer> <LocalLeader>p π
+imap <buffer> <LocalLeader>rho ρ
+imap <buffer> <LocalLeader>r ρ
+imap <buffer> <LocalLeader>sigma σ
+imap <buffer> <LocalLeader>s σ
+imap <buffer> <LocalLeader>varsigma ς
+imap <buffer> <LocalLeader>vars ς
+imap <buffer> <LocalLeader>tau τ
+imap <buffer> <LocalLeader>t τ
+imap <buffer> <LocalLeader>u υ
+imap <buffer> <LocalLeader>phi φ
+imap <buffer> <LocalLeader>f φ
+imap <buffer> <LocalLeader>chi χ
+imap <buffer> <LocalLeader>x χ
+imap <buffer> <LocalLeader>psi ψ
+imap <buffer> <LocalLeader>c ψ
+imap <buffer> <LocalLeader>omega ω
+imap <buffer> <LocalLeader>v ω
 
 " Greek (upper)
-imap <LocalLeader>Alpha Α
-imap <LocalLeader>Beta Β
-imap <LocalLeader>Gamma Γ
-imap <LocalLeader>G Γ
-imap <LocalLeader>Delta Δ
-imap <LocalLeader>D Δ
-imap <LocalLeader>Epsilon Ε
-imap <LocalLeader>Zeta Ζ
-imap <LocalLeader>Eta Η
-imap <LocalLeader>Theta Θ
-imap <LocalLeader>Iota Ι
-imap <LocalLeader>Kappa Κ
-imap <LocalLeader>Lambda Λ
-imap <LocalLeader>L Λ
-imap <LocalLeader>Mu Μ
-imap <LocalLeader>Nu Ν
-imap <LocalLeader>Xi Ξ
-imap <LocalLeader>Omicron Ο
-imap <LocalLeader>Pi Π
-imap <LocalLeader>P Π
-imap <LocalLeader>Rho Ρ
-imap <LocalLeader>Sigma Σ
-imap <LocalLeader>S Σ
-imap <LocalLeader>Tau Τ
-imap <LocalLeader>Upsilon Υ
-imap <LocalLeader>Phi Φ
-imap <LocalLeader>F Φ
-imap <LocalLeader>Chi Χ
-imap <LocalLeader>Psi Ψ
-imap <LocalLeader>Omega Ω
-imap <LocalLeader>V Ω
+imap <buffer> <LocalLeader>Alpha Α
+imap <buffer> <LocalLeader>Beta Β
+imap <buffer> <LocalLeader>Gamma Γ
+imap <buffer> <LocalLeader>G Γ
+imap <buffer> <LocalLeader>Delta Δ
+imap <buffer> <LocalLeader>D Δ
+imap <buffer> <LocalLeader>Epsilon Ε
+imap <buffer> <LocalLeader>Zeta Ζ
+imap <buffer> <LocalLeader>Eta Η
+imap <buffer> <LocalLeader>Theta Θ
+imap <buffer> <LocalLeader>Iota Ι
+imap <buffer> <LocalLeader>Kappa Κ
+imap <buffer> <LocalLeader>Lambda Λ
+imap <buffer> <LocalLeader>L Λ
+imap <buffer> <LocalLeader>Mu Μ
+imap <buffer> <LocalLeader>Nu Ν
+imap <buffer> <LocalLeader>Xi Ξ
+imap <buffer> <LocalLeader>Omicron Ο
+imap <buffer> <LocalLeader>Pi Π
+imap <buffer> <LocalLeader>P Π
+imap <buffer> <LocalLeader>Rho Ρ
+imap <buffer> <LocalLeader>Sigma Σ
+imap <buffer> <LocalLeader>S Σ
+imap <buffer> <LocalLeader>Tau Τ
+imap <buffer> <LocalLeader>Upsilon Υ
+imap <buffer> <LocalLeader>Phi Φ
+imap <buffer> <LocalLeader>F Φ
+imap <buffer> <LocalLeader>Chi Χ
+imap <buffer> <LocalLeader>Psi Ψ
+imap <buffer> <LocalLeader>Omega Ω
+imap <buffer> <LocalLeader>V Ω
 
 " Combining marks
-cmap <LocalLeader>over`  ̀
-cmap <LocalLeader>over'  ́
-cmap <LocalLeader>over^  ̂
-cmap <LocalLeader>overv  ̌
-cmap <LocalLeader>over~  ̃
-cmap <LocalLeader>over-  ̄
-cmap <LocalLeader>over_  ̅
-cmap <LocalLeader>over–  ̅
-cmap <LocalLeader>over—  ̅
-cmap <LocalLeader>overcup  ̆
-cmap <LocalLeader>overcap  ̑
-cmap <LocalLeader>over.  ̇
-cmap <LocalLeader>over..  ̈
-cmap <LocalLeader>over"  ̈
-cmap <LocalLeader>over...  ⃛
-cmap <LocalLeader>overright.  ͘
-cmap <LocalLeader>overo  ̊
-cmap <LocalLeader>over``  ̏
-cmap <LocalLeader>over''  ̋
-cmap <LocalLeader>overvec  ⃑
-cmap <LocalLeader>vec  ⃑
-cmap <LocalLeader>overlvec  ⃐
-cmap <LocalLeader>lvec  ⃐
-cmap <LocalLeader>overarc  ⃕
-cmap <LocalLeader>overlarc  ⃔
-cmap <LocalLeader>overto  ⃗
-cmap <LocalLeader>overfrom  ⃖
-cmap <LocalLeader>overfromto  ⃡
-cmap <LocalLeader>over*  ⃰
-cmap <LocalLeader>under`  ̖
-cmap <LocalLeader>under'  ̗
-cmap <LocalLeader>under,  ̗
-cmap <LocalLeader>under.  ̣
-cmap <LocalLeader>under..  ̤
-cmap <LocalLeader>under"  ̤
-cmap <LocalLeader>undero  ̥
-cmap <LocalLeader>under-  ̱
-cmap <LocalLeader>under_  ̲
-cmap <LocalLeader>under–  ̲
-cmap <LocalLeader>under—  ̲
-cmap <LocalLeader>through~  ̴
-cmap <LocalLeader>through-  ̵
-cmap <LocalLeader>through_  ̶
-cmap <LocalLeader>through–  ̶
-cmap <LocalLeader>through—  ̶
-cmap <LocalLeader>through/  ̷
-cmap <LocalLeader>not  ̷
-cmap <LocalLeader>through?  ̸
-cmap <LocalLeader>Not  ̸
-cmap <LocalLeader>through\|  ⃒
-cmap <LocalLeader>throughshortmid  ⃓
-cmap <LocalLeader>througho  ⃘
+cmap <buffer> <LocalLeader>over`  ̀
+cmap <buffer> <LocalLeader>over'  ́
+cmap <buffer> <LocalLeader>over^  ̂
+cmap <buffer> <LocalLeader>overv  ̌
+cmap <buffer> <LocalLeader>over~  ̃
+cmap <buffer> <LocalLeader>over-  ̄
+cmap <buffer> <LocalLeader>over_  ̅
+cmap <buffer> <LocalLeader>over–  ̅
+cmap <buffer> <LocalLeader>over—  ̅
+cmap <buffer> <LocalLeader>overcup  ̆
+cmap <buffer> <LocalLeader>overcap  ̑
+cmap <buffer> <LocalLeader>over.  ̇
+cmap <buffer> <LocalLeader>over..  ̈
+cmap <buffer> <LocalLeader>over"  ̈
+cmap <buffer> <LocalLeader>over...  ⃛
+cmap <buffer> <LocalLeader>overright.  ͘
+cmap <buffer> <LocalLeader>overo  ̊
+cmap <buffer> <LocalLeader>over``  ̏
+cmap <buffer> <LocalLeader>over''  ̋
+cmap <buffer> <LocalLeader>overvec  ⃑
+cmap <buffer> <LocalLeader>vec  ⃑
+cmap <buffer> <LocalLeader>overlvec  ⃐
+cmap <buffer> <LocalLeader>lvec  ⃐
+cmap <buffer> <LocalLeader>overarc  ⃕
+cmap <buffer> <LocalLeader>overlarc  ⃔
+cmap <buffer> <LocalLeader>overto  ⃗
+cmap <buffer> <LocalLeader>overfrom  ⃖
+cmap <buffer> <LocalLeader>overfromto  ⃡
+cmap <buffer> <LocalLeader>over*  ⃰
+cmap <buffer> <LocalLeader>under`  ̖
+cmap <buffer> <LocalLeader>under'  ̗
+cmap <buffer> <LocalLeader>under,  ̗
+cmap <buffer> <LocalLeader>under.  ̣
+cmap <buffer> <LocalLeader>under..  ̤
+cmap <buffer> <LocalLeader>under"  ̤
+cmap <buffer> <LocalLeader>undero  ̥
+cmap <buffer> <LocalLeader>under-  ̱
+cmap <buffer> <LocalLeader>under_  ̲
+cmap <buffer> <LocalLeader>under–  ̲
+cmap <buffer> <LocalLeader>under—  ̲
+cmap <buffer> <LocalLeader>through~  ̴
+cmap <buffer> <LocalLeader>through-  ̵
+cmap <buffer> <LocalLeader>through_  ̶
+cmap <buffer> <LocalLeader>through–  ̶
+cmap <buffer> <LocalLeader>through—  ̶
+cmap <buffer> <LocalLeader>through/  ̷
+cmap <buffer> <LocalLeader>not  ̷
+cmap <buffer> <LocalLeader>through?  ̸
+cmap <buffer> <LocalLeader>Not  ̸
+cmap <buffer> <LocalLeader>through\|  ⃒
+cmap <buffer> <LocalLeader>throughshortmid  ⃓
+cmap <buffer> <LocalLeader>througho  ⃘
 
 " Math
-cmap <LocalLeader>{{ ⦃
-cmap <LocalLeader>}} ⦄
-cmap <LocalLeader>: ∶
-cmap <LocalLeader>:: ∷
-cmap <LocalLeader>;  ﹔
-cmap <LocalLeader>.. ‥
-cmap <LocalLeader>=? ≟
-cmap <LocalLeader>all ∀
-cmap <LocalLeader>always □
-cmap <LocalLeader>approx ≈
-cmap <LocalLeader>bot ⊥
-cmap <LocalLeader>box □
-cmap <LocalLeader>boxdot ⊡
-cmap <LocalLeader>box. ⊡
-cmap <LocalLeader>boxminus ⊟
-cmap <LocalLeader>box- ⊟
-cmap <LocalLeader>boxplus ⊞
-cmap <LocalLeader>box+ ⊞
-cmap <LocalLeader>boxtimes ⊠
-cmap <LocalLeader>box* ⊠
-cmap <LocalLeader>bul •
-cmap <LocalLeader>C ℂ
-cmap <LocalLeader>cdot ∙
-cmap <LocalLeader>. ∙
-cmap <LocalLeader>cdots ⋯
-cmap <LocalLeader>check ✓
-cmap <LocalLeader>yes ✓
-cmap <LocalLeader>Check ✔
-cmap <LocalLeader>Yes ✔
-cmap <LocalLeader>circ ∘
-cmap <LocalLeader>clock ↻
-cmap <LocalLeader>cclock ↺
-cmap <LocalLeader>comp ∘
-cmap <LocalLeader>contra ↯
-cmap <LocalLeader>deg °
-cmap <LocalLeader>den ⟦⟧<left>
-cmap <LocalLeader>diamond ◇
-cmap <LocalLeader>dots …
-cmap <LocalLeader>down ↓
-cmap <LocalLeader>downtri ▼
-cmap <LocalLeader>Down ⇓
-cmap <LocalLeader>dunion ⊎
-cmap <LocalLeader>du ⊎
-cmap <LocalLeader>ell ℓ
-cmap <LocalLeader>empty ∅
-cmap <LocalLeader>equiv ≡
-cmap <LocalLeader>eq ≡
-cmap <LocalLeader>eventually ◇
-cmap <LocalLeader>exists ∃
-cmap <LocalLeader>flat ♭
-cmap <LocalLeader>fold ⦇⦈<left>
-cmap <LocalLeader>(\| ⦇
-cmap <LocalLeader>\|) ⦈
-cmap <LocalLeader>forall ∀
-cmap <LocalLeader>from ←
-cmap <LocalLeader><- ←
-cmap <LocalLeader>From ⇐
-cmap <LocalLeader>fromto ↔
-cmap <LocalLeader>Fromto ⇔
-cmap <LocalLeader>ge ≥
-cmap <LocalLeader>glub ⊓
-cmap <LocalLeader>iff ⇔
-cmap <LocalLeader>implies ⇒
-cmap <LocalLeader>impliedby ⇐
-cmap <LocalLeader>in ∈
-cmap <LocalLeader>infty ∞
-cmap <LocalLeader>inf ∞
-cmap <LocalLeader>int ∫
-cmap <LocalLeader>intersect ∩
-cmap <LocalLeader>iso ≅
-cmap <LocalLeader>join ⋈
-cmap <LocalLeader>land ∧
-cmap <LocalLeader>langle ⟨
-cmap <LocalLeader>lbrac ⟦
-cmap <LocalLeader>[[ ⟦
-cmap <LocalLeader>ldots …
-cmap <LocalLeader>ldown ⇃
-cmap <LocalLeader>leadsto ⇝
-cmap <LocalLeader>~> ⇝
-cmap <LocalLeader>le ≤
-cmap <LocalLeader>lift ⌊⌋<left>
-cmap <LocalLeader>floor ⌊⌋<left>
-cmap <LocalLeader>llangle ⟪
-cmap <LocalLeader>longto ⟶ 
-cmap <LocalLeader>-- ⟶ 
-cmap <LocalLeader>– ⟶ 
-cmap <LocalLeader>lor ∨
-cmap <LocalLeader>lower ⌈⌉<left>
-cmap <LocalLeader>ceil ⌈⌉<left>
-cmap <LocalLeader>lub ⊔
-cmap <LocalLeader>lup ↿
-cmap <LocalLeader>mapsto ↦
-cmap <LocalLeader>map ↦
-cmap <LocalLeader>mid ∣
-cmap <LocalLeader>models ⊨
-cmap <LocalLeader>\|= ⊨
-cmap <LocalLeader>N ℕ
-cmap <LocalLeader>ne ≠
-cmap <LocalLeader>nearrow ↗
-cmap <LocalLeader>Nearrow ⇗
-cmap <LocalLeader>neg ¬
-cmap <LocalLeader>/= ≠
-cmap <LocalLeader>nequiv ≢
-cmap <LocalLeader>neq ≢
-cmap <LocalLeader>nexist ∄
-cmap <LocalLeader>none ∄
-cmap <LocalLeader>ni ∋
-cmap <LocalLeader>ni ∋
-cmap <LocalLeader>nin ∉
-cmap <LocalLeader>niso ≇
-cmap <LocalLeader>notin ∉
-cmap <LocalLeader>nwarrow ↖
-cmap <LocalLeader>Nwarrow ⇖
-cmap <LocalLeader>oast ⊛
-cmap <LocalLeader>odot ⊙
-cmap <LocalLeader>o. ⊙
-cmap <LocalLeader>of ∘
-cmap <LocalLeader>o ∘
-cmap <LocalLeader>ominus ⊖
-cmap <LocalLeader>o- ⊖
-cmap <LocalLeader>oplus ⊕
-cmap <LocalLeader>o+ ⊕
-cmap <LocalLeader>oslash ⊘
-cmap <LocalLeader>o/ ⊘
-cmap <LocalLeader>otimes ⊗
-cmap <LocalLeader>o* ⊗
-cmap <LocalLeader>par ∂
-cmap <LocalLeader>pge ≽
-cmap <LocalLeader>pgt ≻
-cmap <LocalLeader>ple ≼
-cmap <LocalLeader>plt ≺
-cmap <LocalLeader>p≥ ≽
-cmap <LocalLeader>p> ≻
-cmap <LocalLeader>p≤ ≼
-cmap <LocalLeader>p< ≺
-cmap <LocalLeader>pm ±
-cmap <LocalLeader>prec ≼
-cmap <LocalLeader>prod ∏
-cmap <LocalLeader>proves ⊢
-cmap <LocalLeader>\|- ⊢
-cmap <LocalLeader>provedby ⊣
-cmap <LocalLeader>Q ℚ
-cmap <LocalLeader>qed ∎
-cmap <LocalLeader>R ℝ
-cmap <LocalLeader>rangle ⟩
-cmap <LocalLeader>rbrac ⟧
-cmap <LocalLeader>]] ⟧
-cmap <LocalLeader>rdown ⇂
-cmap <LocalLeader>righttri ▸
-cmap <LocalLeader>rrangle ⟫
-cmap <LocalLeader>rup ↾
-cmap <LocalLeader>searrow ↘
-cmap <LocalLeader>Searrow ⇘
-cmap <LocalLeader>setminus ∖
-cmap <LocalLeader>sharp ♯
-cmap <LocalLeader># ♯
-cmap <LocalLeader>sim ∼
-cmap <LocalLeader>simeq ≃
-cmap <LocalLeader>some ∃
-cmap <LocalLeader>sqge ⊒
-cmap <LocalLeader>sqgt ⊐
-cmap <LocalLeader>sqle ⊑
-cmap <LocalLeader>sqlt ⊏
-cmap <LocalLeader>s≥ ⊒
-cmap <LocalLeader>s> ⊐
-cmap <LocalLeader>s≤ ⊑
-cmap <LocalLeader>s< ⊏
-cmap <LocalLeader>sqr ²
-cmap <LocalLeader>sqrt √
-cmap <LocalLeader>star ✭
-cmap <LocalLeader>subset ⊂
-cmap <LocalLeader>sub ⊂
-cmap <LocalLeader>subseteq ⊆
-cmap <LocalLeader>subeq ⊆
-cmap <LocalLeader>subsetneq ⊊
-cmap <LocalLeader>subneq ⊊
-cmap <LocalLeader>sum ∑
-cmap <LocalLeader>supset ⊃
-cmap <LocalLeader>sup ⊃
-cmap <LocalLeader>supseteq ⊇
-cmap <LocalLeader>supeq ⊇
-cmap <LocalLeader>supsetneq ⊋
-cmap <LocalLeader>supneq ⊋
-cmap <LocalLeader>swarrow ↙
-cmap <LocalLeader>Swarrow ⇙
-cmap <LocalLeader>thus ∴
-cmap <LocalLeader>times ×
-cmap <LocalLeader>* ×
-cmap <LocalLeader>to →
-cmap <LocalLeader>- →
-cmap <C-_> →
-cmap <LocalLeader>To ⇒
-cmap <LocalLeader>= ⇒
-cmap <LocalLeader>top ⊤
-cmap <LocalLeader>tuple ⟨⟩<left>
-cmap <LocalLeader>up ↑
-cmap <LocalLeader>updown ↕
-cmap <LocalLeader>ud ↕
-cmap <LocalLeader>unfold ⦉⦊<left>
-cmap <LocalLeader><\| ⦉
-cmap <LocalLeader>\|> ⦊
-cmap <LocalLeader>up;down ⇅
-cmap <LocalLeader>u;d ⇅
-cmap <LocalLeader>uptri ▲
-cmap <LocalLeader>Up ⇑
-cmap <LocalLeader>union ∪
-cmap <LocalLeader>vdots ⋮
-cmap <LocalLeader>voltage ⚡
-cmap <LocalLeader>xmark ✗
-cmap <LocalLeader>no ✗
-cmap <LocalLeader>Xmark ✘
-cmap <LocalLeader>No ✘
-cmap <LocalLeader>Z ℤ
+cmap <buffer> <LocalLeader>{{ ⦃
+cmap <buffer> <LocalLeader>}} ⦄
+cmap <buffer> <LocalLeader>: ∶
+cmap <buffer> <LocalLeader>:: ∷
+cmap <buffer> <LocalLeader>;  ﹔
+cmap <buffer> <LocalLeader>.. ‥
+cmap <buffer> <LocalLeader>=? ≟
+cmap <buffer> <LocalLeader>all ∀
+cmap <buffer> <LocalLeader>always □
+cmap <buffer> <LocalLeader>approx ≈
+cmap <buffer> <LocalLeader>bot ⊥
+cmap <buffer> <LocalLeader>box □
+cmap <buffer> <LocalLeader>boxdot ⊡
+cmap <buffer> <LocalLeader>box. ⊡
+cmap <buffer> <LocalLeader>boxminus ⊟
+cmap <buffer> <LocalLeader>box- ⊟
+cmap <buffer> <LocalLeader>boxplus ⊞
+cmap <buffer> <LocalLeader>box+ ⊞
+cmap <buffer> <LocalLeader>boxtimes ⊠
+cmap <buffer> <LocalLeader>box* ⊠
+cmap <buffer> <LocalLeader>bul •
+cmap <buffer> <LocalLeader>C ℂ
+cmap <buffer> <LocalLeader>cdot ∙
+cmap <buffer> <LocalLeader>. ∙
+cmap <buffer> <LocalLeader>cdots ⋯
+cmap <buffer> <LocalLeader>check ✓
+cmap <buffer> <LocalLeader>yes ✓
+cmap <buffer> <LocalLeader>Check ✔
+cmap <buffer> <LocalLeader>Yes ✔
+cmap <buffer> <LocalLeader>circ ∘
+cmap <buffer> <LocalLeader>clock ↻
+cmap <buffer> <LocalLeader>cclock ↺
+cmap <buffer> <LocalLeader>comp ∘
+cmap <buffer> <LocalLeader>contra ↯
+cmap <buffer> <LocalLeader>deg °
+cmap <buffer> <LocalLeader>den ⟦⟧<left>
+cmap <buffer> <LocalLeader>diamond ◇
+cmap <buffer> <LocalLeader>dots …
+cmap <buffer> <LocalLeader>down ↓
+cmap <buffer> <LocalLeader>downtri ▼
+cmap <buffer> <LocalLeader>Down ⇓
+cmap <buffer> <LocalLeader>dunion ⊎
+cmap <buffer> <LocalLeader>du ⊎
+cmap <buffer> <LocalLeader>ell ℓ
+cmap <buffer> <LocalLeader>empty ∅
+cmap <buffer> <LocalLeader>equiv ≡
+cmap <buffer> <LocalLeader>eq ≡
+cmap <buffer> <LocalLeader>eventually ◇
+cmap <buffer> <LocalLeader>exists ∃
+cmap <buffer> <LocalLeader>flat ♭
+cmap <buffer> <LocalLeader>fold ⦇⦈<left>
+cmap <buffer> <LocalLeader>(\| ⦇
+cmap <buffer> <LocalLeader>\|) ⦈
+cmap <buffer> <LocalLeader>forall ∀
+cmap <buffer> <LocalLeader>from ←
+cmap <buffer> <LocalLeader><- ←
+cmap <buffer> <LocalLeader>From ⇐
+cmap <buffer> <LocalLeader>fromto ↔
+cmap <buffer> <LocalLeader>Fromto ⇔
+cmap <buffer> <LocalLeader>ge ≥
+cmap <buffer> <LocalLeader>glub ⊓
+cmap <buffer> <LocalLeader>iff ⇔
+cmap <buffer> <LocalLeader>implies ⇒
+cmap <buffer> <LocalLeader>impliedby ⇐
+cmap <buffer> <LocalLeader>in ∈
+cmap <buffer> <LocalLeader>infty ∞
+cmap <buffer> <LocalLeader>inf ∞
+cmap <buffer> <LocalLeader>int ∫
+cmap <buffer> <LocalLeader>intersect ∩
+cmap <buffer> <LocalLeader>iso ≅
+cmap <buffer> <LocalLeader>join ⋈
+cmap <buffer> <LocalLeader>land ∧
+cmap <buffer> <LocalLeader>langle ⟨
+cmap <buffer> <LocalLeader>lbrac ⟦
+cmap <buffer> <LocalLeader>[[ ⟦
+cmap <buffer> <LocalLeader>ldots …
+cmap <buffer> <LocalLeader>ldown ⇃
+cmap <buffer> <LocalLeader>leadsto ⇝
+cmap <buffer> <LocalLeader>~> ⇝
+cmap <buffer> <LocalLeader>le ≤
+cmap <buffer> <LocalLeader>lift ⌊⌋<left>
+cmap <buffer> <LocalLeader>floor ⌊⌋<left>
+cmap <buffer> <LocalLeader>llangle ⟪
+cmap <buffer> <LocalLeader>longto ⟶ 
+cmap <buffer> <LocalLeader>-- ⟶ 
+cmap <buffer> <LocalLeader>– ⟶ 
+cmap <buffer> <LocalLeader>lor ∨
+cmap <buffer> <LocalLeader>lower ⌈⌉<left>
+cmap <buffer> <LocalLeader>ceil ⌈⌉<left>
+cmap <buffer> <LocalLeader>lub ⊔
+cmap <buffer> <LocalLeader>lup ↿
+cmap <buffer> <LocalLeader>mapsto ↦
+cmap <buffer> <LocalLeader>map ↦
+cmap <buffer> <LocalLeader>mid ∣
+cmap <buffer> <LocalLeader>models ⊨
+cmap <buffer> <LocalLeader>\|= ⊨
+cmap <buffer> <LocalLeader>N ℕ
+cmap <buffer> <LocalLeader>ne ≠
+cmap <buffer> <LocalLeader>nearrow ↗
+cmap <buffer> <LocalLeader>Nearrow ⇗
+cmap <buffer> <LocalLeader>neg ¬
+cmap <buffer> <LocalLeader>/= ≠
+cmap <buffer> <LocalLeader>nequiv ≢
+cmap <buffer> <LocalLeader>neq ≢
+cmap <buffer> <LocalLeader>nexist ∄
+cmap <buffer> <LocalLeader>none ∄
+cmap <buffer> <LocalLeader>ni ∋
+cmap <buffer> <LocalLeader>ni ∋
+cmap <buffer> <LocalLeader>nin ∉
+cmap <buffer> <LocalLeader>niso ≇
+cmap <buffer> <LocalLeader>notin ∉
+cmap <buffer> <LocalLeader>nwarrow ↖
+cmap <buffer> <LocalLeader>Nwarrow ⇖
+cmap <buffer> <LocalLeader>oast ⊛
+cmap <buffer> <LocalLeader>odot ⊙
+cmap <buffer> <LocalLeader>o. ⊙
+cmap <buffer> <LocalLeader>of ∘
+cmap <buffer> <LocalLeader>o ∘
+cmap <buffer> <LocalLeader>ominus ⊖
+cmap <buffer> <LocalLeader>o- ⊖
+cmap <buffer> <LocalLeader>oplus ⊕
+cmap <buffer> <LocalLeader>o+ ⊕
+cmap <buffer> <LocalLeader>oslash ⊘
+cmap <buffer> <LocalLeader>o/ ⊘
+cmap <buffer> <LocalLeader>otimes ⊗
+cmap <buffer> <LocalLeader>o* ⊗
+cmap <buffer> <LocalLeader>par ∂
+cmap <buffer> <LocalLeader>pge ≽
+cmap <buffer> <LocalLeader>pgt ≻
+cmap <buffer> <LocalLeader>ple ≼
+cmap <buffer> <LocalLeader>plt ≺
+cmap <buffer> <LocalLeader>p≥ ≽
+cmap <buffer> <LocalLeader>p> ≻
+cmap <buffer> <LocalLeader>p≤ ≼
+cmap <buffer> <LocalLeader>p< ≺
+cmap <buffer> <LocalLeader>pm ±
+cmap <buffer> <LocalLeader>prec ≼
+cmap <buffer> <LocalLeader>prod ∏
+cmap <buffer> <LocalLeader>proves ⊢
+cmap <buffer> <LocalLeader>\|- ⊢
+cmap <buffer> <LocalLeader>provedby ⊣
+cmap <buffer> <LocalLeader>Q ℚ
+cmap <buffer> <LocalLeader>qed ∎
+cmap <buffer> <LocalLeader>R ℝ
+cmap <buffer> <LocalLeader>rangle ⟩
+cmap <buffer> <LocalLeader>rbrac ⟧
+cmap <buffer> <LocalLeader>]] ⟧
+cmap <buffer> <LocalLeader>rdown ⇂
+cmap <buffer> <LocalLeader>righttri ▸
+cmap <buffer> <LocalLeader>rrangle ⟫
+cmap <buffer> <LocalLeader>rup ↾
+cmap <buffer> <LocalLeader>searrow ↘
+cmap <buffer> <LocalLeader>Searrow ⇘
+cmap <buffer> <LocalLeader>setminus ∖
+cmap <buffer> <LocalLeader>sharp ♯
+cmap <buffer> <LocalLeader># ♯
+cmap <buffer> <LocalLeader>sim ∼
+cmap <buffer> <LocalLeader>simeq ≃
+cmap <buffer> <LocalLeader>some ∃
+cmap <buffer> <LocalLeader>sqge ⊒
+cmap <buffer> <LocalLeader>sqgt ⊐
+cmap <buffer> <LocalLeader>sqle ⊑
+cmap <buffer> <LocalLeader>sqlt ⊏
+cmap <buffer> <LocalLeader>s≥ ⊒
+cmap <buffer> <LocalLeader>s> ⊐
+cmap <buffer> <LocalLeader>s≤ ⊑
+cmap <buffer> <LocalLeader>s< ⊏
+cmap <buffer> <LocalLeader>sqr ²
+cmap <buffer> <LocalLeader>sqrt √
+cmap <buffer> <LocalLeader>star ✭
+cmap <buffer> <LocalLeader>subset ⊂
+cmap <buffer> <LocalLeader>sub ⊂
+cmap <buffer> <LocalLeader>subseteq ⊆
+cmap <buffer> <LocalLeader>subeq ⊆
+cmap <buffer> <LocalLeader>subsetneq ⊊
+cmap <buffer> <LocalLeader>subneq ⊊
+cmap <buffer> <LocalLeader>sum ∑
+cmap <buffer> <LocalLeader>supset ⊃
+cmap <buffer> <LocalLeader>sup ⊃
+cmap <buffer> <LocalLeader>supseteq ⊇
+cmap <buffer> <LocalLeader>supeq ⊇
+cmap <buffer> <LocalLeader>supsetneq ⊋
+cmap <buffer> <LocalLeader>supneq ⊋
+cmap <buffer> <LocalLeader>swarrow ↙
+cmap <buffer> <LocalLeader>Swarrow ⇙
+cmap <buffer> <LocalLeader>thus ∴
+cmap <buffer> <LocalLeader>times ×
+cmap <buffer> <LocalLeader>* ×
+cmap <buffer> <LocalLeader>to →
+cmap <buffer> <LocalLeader>- →
+cmap <buffer> <C-_> →
+cmap <buffer> <LocalLeader>To ⇒
+cmap <buffer> <LocalLeader>= ⇒
+cmap <buffer> <LocalLeader>top ⊤
+cmap <buffer> <LocalLeader>tuple ⟨⟩<left>
+cmap <buffer> <LocalLeader>up ↑
+cmap <buffer> <LocalLeader>updown ↕
+cmap <buffer> <LocalLeader>ud ↕
+cmap <buffer> <LocalLeader>unfold ⦉⦊<left>
+cmap <buffer> <LocalLeader><\| ⦉
+cmap <buffer> <LocalLeader>\|> ⦊
+cmap <buffer> <LocalLeader>up;down ⇅
+cmap <buffer> <LocalLeader>u;d ⇅
+cmap <buffer> <LocalLeader>uptri ▲
+cmap <buffer> <LocalLeader>Up ⇑
+cmap <buffer> <LocalLeader>union ∪
+cmap <buffer> <LocalLeader>vdots ⋮
+cmap <buffer> <LocalLeader>voltage ⚡
+cmap <buffer> <LocalLeader>xmark ✗
+cmap <buffer> <LocalLeader>no ✗
+cmap <buffer> <LocalLeader>Xmark ✘
+cmap <buffer> <LocalLeader>No ✘
+cmap <buffer> <LocalLeader>Z ℤ
 
 " Not math
-cmap <LocalLeader>sec §
+cmap <buffer> <LocalLeader>sec §
 
 " Superscripts
-cmap <LocalLeader>^0 ⁰
-cmap <LocalLeader>^1 ¹
-cmap <LocalLeader>^2 ²
-cmap <LocalLeader>^3 ³
-cmap <LocalLeader>^4 ⁴
-cmap <LocalLeader>^5 ⁵
-cmap <LocalLeader>^6 ⁶
-cmap <LocalLeader>^7 ⁷
-cmap <LocalLeader>^8 ⁸
-cmap <LocalLeader>^9 ⁹
-cmap <LocalLeader>^n ⁿ
-cmap <LocalLeader>^i ⁱ
-cmap <LocalLeader>^+ ⁺
-cmap <LocalLeader>^- ⁻
-cmap <LocalLeader>' ′
-cmap <LocalLeader>'' ″
-cmap <LocalLeader>''' ‴
-cmap <LocalLeader>'''' ⁗
-cmap <LocalLeader>" ″
-cmap <LocalLeader>"" ⁗
-cmap <LocalLeader>` ‵
-cmap <LocalLeader>`` ‶
-cmap <LocalLeader>``` ‷
+cmap <buffer> <LocalLeader>^0 ⁰
+cmap <buffer> <LocalLeader>^1 ¹
+cmap <buffer> <LocalLeader>^2 ²
+cmap <buffer> <LocalLeader>^3 ³
+cmap <buffer> <LocalLeader>^4 ⁴
+cmap <buffer> <LocalLeader>^5 ⁵
+cmap <buffer> <LocalLeader>^6 ⁶
+cmap <buffer> <LocalLeader>^7 ⁷
+cmap <buffer> <LocalLeader>^8 ⁸
+cmap <buffer> <LocalLeader>^9 ⁹
+cmap <buffer> <LocalLeader>^n ⁿ
+cmap <buffer> <LocalLeader>^i ⁱ
+cmap <buffer> <LocalLeader>^+ ⁺
+cmap <buffer> <LocalLeader>^- ⁻
+cmap <buffer> <LocalLeader>' ′
+cmap <buffer> <LocalLeader>'' ″
+cmap <buffer> <LocalLeader>''' ‴
+cmap <buffer> <LocalLeader>'''' ⁗
+cmap <buffer> <LocalLeader>" ″
+cmap <buffer> <LocalLeader>"" ⁗
+cmap <buffer> <LocalLeader>` ‵
+cmap <buffer> <LocalLeader>`` ‶
+cmap <buffer> <LocalLeader>``` ‷
 
 " Subscripts
-cmap <LocalLeader>0 ₀
-cmap <LocalLeader>1 ₁
-cmap <LocalLeader>2 ₂
-cmap <LocalLeader>3 ₃
-cmap <LocalLeader>4 ₄
-cmap <LocalLeader>5 ₅
-cmap <LocalLeader>6 ₆
-cmap <LocalLeader>7 ₇
-cmap <LocalLeader>8 ₈
-cmap <LocalLeader>9 ₉
-cmap <LocalLeader>_i ᵢ
-cmap <LocalLeader>_j ⱼ
-cmap <LocalLeader>_+ ₊
-cmap <LocalLeader>_- ₋
-cmap <LocalLeader>p0 π₀
-cmap <LocalLeader>p1 π₁
-cmap <LocalLeader>p2 π₂
-cmap <LocalLeader>p3 π₃
-cmap <LocalLeader>p4 π₄
-cmap <LocalLeader>p5 π₅
-cmap <LocalLeader>p6 π₆
-cmap <LocalLeader>p7 π₇
-cmap <LocalLeader>p8 π₈
-cmap <LocalLeader>p9 π₉
-cmap <LocalLeader>i0 ι₀
-cmap <LocalLeader>i1 ι₁
-cmap <LocalLeader>i2 ι₂
-cmap <LocalLeader>i3 ι₃
-cmap <LocalLeader>i4 ι₄
-cmap <LocalLeader>i5 ι₅
-cmap <LocalLeader>i6 ι₆
-cmap <LocalLeader>i7 ι₇
-cmap <LocalLeader>i8 ι₈
-cmap <LocalLeader>i9 ι₉
+cmap <buffer> <LocalLeader>0 ₀
+cmap <buffer> <LocalLeader>1 ₁
+cmap <buffer> <LocalLeader>2 ₂
+cmap <buffer> <LocalLeader>3 ₃
+cmap <buffer> <LocalLeader>4 ₄
+cmap <buffer> <LocalLeader>5 ₅
+cmap <buffer> <LocalLeader>6 ₆
+cmap <buffer> <LocalLeader>7 ₇
+cmap <buffer> <LocalLeader>8 ₈
+cmap <buffer> <LocalLeader>9 ₉
+cmap <buffer> <LocalLeader>_i ᵢ
+cmap <buffer> <LocalLeader>_j ⱼ
+cmap <buffer> <LocalLeader>_+ ₊
+cmap <buffer> <LocalLeader>_- ₋
+cmap <buffer> <LocalLeader>p0 π₀
+cmap <buffer> <LocalLeader>p1 π₁
+cmap <buffer> <LocalLeader>p2 π₂
+cmap <buffer> <LocalLeader>p3 π₃
+cmap <buffer> <LocalLeader>p4 π₄
+cmap <buffer> <LocalLeader>p5 π₅
+cmap <buffer> <LocalLeader>p6 π₆
+cmap <buffer> <LocalLeader>p7 π₇
+cmap <buffer> <LocalLeader>p8 π₈
+cmap <buffer> <LocalLeader>p9 π₉
+cmap <buffer> <LocalLeader>i0 ι₀
+cmap <buffer> <LocalLeader>i1 ι₁
+cmap <buffer> <LocalLeader>i2 ι₂
+cmap <buffer> <LocalLeader>i3 ι₃
+cmap <buffer> <LocalLeader>i4 ι₄
+cmap <buffer> <LocalLeader>i5 ι₅
+cmap <buffer> <LocalLeader>i6 ι₆
+cmap <buffer> <LocalLeader>i7 ι₇
+cmap <buffer> <LocalLeader>i8 ι₈
+cmap <buffer> <LocalLeader>i9 ι₉
 
 " Greek (lower)
-cmap <LocalLeader>alpha α
-cmap <LocalLeader>a α
-cmap <LocalLeader>beta β
-cmap <LocalLeader>b β
-cmap <LocalLeader>gamma γ
-cmap <LocalLeader>g γ
-cmap <LocalLeader>delta δ
-cmap <LocalLeader>d δ
-cmap <LocalLeader>epsilon ε
-cmap <LocalLeader>e ε
-cmap <LocalLeader>zeta ζ
-cmap <LocalLeader>z ζ
-cmap <LocalLeader>eta η
-cmap <LocalLeader>h η
-cmap <LocalLeader>theta θ
-cmap <LocalLeader>iota ι
-cmap <LocalLeader>i ι
-cmap <LocalLeader>kappa κ
-cmap <LocalLeader>k κ
-cmap <LocalLeader>lambda λ
-cmap <LocalLeader>l λ
-cmap <LocalLeader>mu μ
-cmap <LocalLeader>m μ
-cmap <LocalLeader>nu ν
-cmap <LocalLeader>n ν
-cmap <LocalLeader>xi ξ
-cmap <LocalLeader>omicron ο
-cmap <LocalLeader>pi π
-cmap <LocalLeader>p π
-cmap <LocalLeader>rho ρ
-cmap <LocalLeader>r ρ
-cmap <LocalLeader>sigma σ
-cmap <LocalLeader>s σ
-cmap <LocalLeader>varsigma ς
-cmap <LocalLeader>vars ς
-cmap <LocalLeader>tau τ
-cmap <LocalLeader>t τ
-cmap <LocalLeader>u υ
-cmap <LocalLeader>phi φ
-cmap <LocalLeader>f φ
-cmap <LocalLeader>chi χ
-cmap <LocalLeader>x χ
-cmap <LocalLeader>psi ψ
-cmap <LocalLeader>c ψ
-cmap <LocalLeader>omega ω
-cmap <LocalLeader>v ω
+cmap <buffer> <LocalLeader>alpha α
+cmap <buffer> <LocalLeader>a α
+cmap <buffer> <LocalLeader>beta β
+cmap <buffer> <LocalLeader>b β
+cmap <buffer> <LocalLeader>gamma γ
+cmap <buffer> <LocalLeader>g γ
+cmap <buffer> <LocalLeader>delta δ
+cmap <buffer> <LocalLeader>d δ
+cmap <buffer> <LocalLeader>epsilon ε
+cmap <buffer> <LocalLeader>e ε
+cmap <buffer> <LocalLeader>zeta ζ
+cmap <buffer> <LocalLeader>z ζ
+cmap <buffer> <LocalLeader>eta η
+cmap <buffer> <LocalLeader>h η
+cmap <buffer> <LocalLeader>theta θ
+cmap <buffer> <LocalLeader>iota ι
+cmap <buffer> <LocalLeader>i ι
+cmap <buffer> <LocalLeader>kappa κ
+cmap <buffer> <LocalLeader>k κ
+cmap <buffer> <LocalLeader>lambda λ
+cmap <buffer> <LocalLeader>l λ
+cmap <buffer> <LocalLeader>mu μ
+cmap <buffer> <LocalLeader>m μ
+cmap <buffer> <LocalLeader>nu ν
+cmap <buffer> <LocalLeader>n ν
+cmap <buffer> <LocalLeader>xi ξ
+cmap <buffer> <LocalLeader>omicron ο
+cmap <buffer> <LocalLeader>pi π
+cmap <buffer> <LocalLeader>p π
+cmap <buffer> <LocalLeader>rho ρ
+cmap <buffer> <LocalLeader>r ρ
+cmap <buffer> <LocalLeader>sigma σ
+cmap <buffer> <LocalLeader>s σ
+cmap <buffer> <LocalLeader>varsigma ς
+cmap <buffer> <LocalLeader>vars ς
+cmap <buffer> <LocalLeader>tau τ
+cmap <buffer> <LocalLeader>t τ
+cmap <buffer> <LocalLeader>u υ
+cmap <buffer> <LocalLeader>phi φ
+cmap <buffer> <LocalLeader>f φ
+cmap <buffer> <LocalLeader>chi χ
+cmap <buffer> <LocalLeader>x χ
+cmap <buffer> <LocalLeader>psi ψ
+cmap <buffer> <LocalLeader>c ψ
+cmap <buffer> <LocalLeader>omega ω
+cmap <buffer> <LocalLeader>v ω
 
 " Greek (upper)
-cmap <LocalLeader>Alpha Α
-cmap <LocalLeader>Beta Β
-cmap <LocalLeader>Gamma Γ
-cmap <LocalLeader>G Γ
-cmap <LocalLeader>Delta Δ
-cmap <LocalLeader>D Δ
-cmap <LocalLeader>Epsilon Ε
-cmap <LocalLeader>Zeta Ζ
-cmap <LocalLeader>Eta Η
-cmap <LocalLeader>Theta Θ
-cmap <LocalLeader>Iota Ι
-cmap <LocalLeader>Kappa Κ
-cmap <LocalLeader>Lambda Λ
-cmap <LocalLeader>L Λ
-cmap <LocalLeader>Mu Μ
-cmap <LocalLeader>Nu Ν
-cmap <LocalLeader>Xi Ξ
-cmap <LocalLeader>Omicron Ο
-cmap <LocalLeader>Pi Π
-cmap <LocalLeader>P Π
-cmap <LocalLeader>Rho Ρ
-cmap <LocalLeader>Sigma Σ
-cmap <LocalLeader>S Σ
-cmap <LocalLeader>Tau Τ
-cmap <LocalLeader>Upsilon Υ
-cmap <LocalLeader>Phi Φ
-cmap <LocalLeader>F Φ
-cmap <LocalLeader>Chi Χ
-cmap <LocalLeader>Psi Ψ
-cmap <LocalLeader>Omega Ω
-cmap <LocalLeader>V Ω
+cmap <buffer> <LocalLeader>Alpha Α
+cmap <buffer> <LocalLeader>Beta Β
+cmap <buffer> <LocalLeader>Gamma Γ
+cmap <buffer> <LocalLeader>G Γ
+cmap <buffer> <LocalLeader>Delta Δ
+cmap <buffer> <LocalLeader>D Δ
+cmap <buffer> <LocalLeader>Epsilon Ε
+cmap <buffer> <LocalLeader>Zeta Ζ
+cmap <buffer> <LocalLeader>Eta Η
+cmap <buffer> <LocalLeader>Theta Θ
+cmap <buffer> <LocalLeader>Iota Ι
+cmap <buffer> <LocalLeader>Kappa Κ
+cmap <buffer> <LocalLeader>Lambda Λ
+cmap <buffer> <LocalLeader>L Λ
+cmap <buffer> <LocalLeader>Mu Μ
+cmap <buffer> <LocalLeader>Nu Ν
+cmap <buffer> <LocalLeader>Xi Ξ
+cmap <buffer> <LocalLeader>Omicron Ο
+cmap <buffer> <LocalLeader>Pi Π
+cmap <buffer> <LocalLeader>P Π
+cmap <buffer> <LocalLeader>Rho Ρ
+cmap <buffer> <LocalLeader>Sigma Σ
+cmap <buffer> <LocalLeader>S Σ
+cmap <buffer> <LocalLeader>Tau Τ
+cmap <buffer> <LocalLeader>Upsilon Υ
+cmap <buffer> <LocalLeader>Phi Φ
+cmap <buffer> <LocalLeader>F Φ
+cmap <buffer> <LocalLeader>Chi Χ
+cmap <buffer> <LocalLeader>Psi Ψ
+cmap <buffer> <LocalLeader>Omega Ω
+cmap <buffer> <LocalLeader>V Ω


### PR DESCRIPTION
Once I load an Agda file all my buffers have the Agda UTF8 mappings even if they are not using the Agda mode. This should not happen.