### PR TITLE
updated unfold abstract flags in Normalize()

### DIFF
--- a/ftplugin/agda.vim
+++ b/ftplugin/agda.vim
@@ -486,8 +486,8 @@ nnoremap <buffer> <LocalLeader>g :call Give()<CR>
 nnoremap <buffer> <LocalLeader>c :call MakeCase()<CR>
 nnoremap <buffer> <LocalLeader>a :call Auto()<CR>
 nnoremap <buffer> <LocalLeader>e :call Context()<CR>
-nnoremap <buffer> <LocalLeader>n :call Normalize("False")<CR>
-nnoremap <buffer> <LocalLeader>N :call Normalize("True")<CR>
+nnoremap <buffer> <LocalLeader>n :call Normalize("IgnoreAbstract")<CR>
+nnoremap <buffer> <LocalLeader>N :call Normalize("DefaultCompute")<CR>
 nnoremap <buffer> <LocalLeader>M :call ShowModule('')<CR>
 nnoremap <buffer> <LocalLeader>y :call WhyInScope('')<CR>
 nnoremap <buffer> <LocalLeader>m :Metas<CR>


### PR DESCRIPTION
`Normalize` wasn't working for me when using agda version 2.5.2

The command flags seemed to have changed between versions.