### PR TITLE
unfoldAbstract not found fix

### DIFF
--- a/ftplugin/agda.vim
+++ b/ftplugin/agda.vim
@@ -486,8 +486,8 @@ nnoremap <buffer> <LocalLeader>g :call Give()<CR>
 nnoremap <buffer> <LocalLeader>c :call MakeCase()<CR>
 nnoremap <buffer> <LocalLeader>a :call Auto()<CR>
 nnoremap <buffer> <LocalLeader>e :call Context()<CR>
-nnoremap <buffer> <LocalLeader>n :call Normalize("False")<CR>
-nnoremap <buffer> <LocalLeader>N :call Normalize("True")<CR>
+nnoremap <buffer> <LocalLeader>n :call Normalize("IgnoreAbstract")<CR>
+nnoremap <buffer> <LocalLeader>N :call Normalize("DefaultCompute")<CR>
 nnoremap <buffer> <LocalLeader>M :call ShowModule('')<CR>
 nnoremap <buffer> <LocalLeader>y :call WhyInScope('')<CR>
 nnoremap <buffer> <LocalLeader>m :Metas<CR>

--- a/ftplugin/agda.vim
+++ b/ftplugin/agda.vim
@@ -207,6 +207,11 @@ def parseVersion(versionString):
     global agdaVersion
     agdaVersion = [int(c) for c in versionString[12:].split('.')]
 
+def compareVersion(versionList, compare):
+    versionNum = int(''.join(map(str,versionList)))
+    agdaVersionNum = int(''.join(map(str,agdaVersion)))
+    return compare(versionNum, agdaVersionNum)
+
 def interpretResponse(responses, quiet = False):
     for response in responses:
         if response.startswith('(agda2-info-action '):
@@ -413,17 +418,20 @@ endfunction
 function! Normalize(unfoldAbstract)
 exec s:python_until_eof
 import vim
+import operator
 
-if agdaVersion < [2,5,2,0]:
+unfoldAbstract = vim.eval("a:unfoldAbstract")
+
+if compareVersion([2,5,2,0], operator.lt):
     unfoldAbstract = str(unfoldAbstract == "DefaultCompute")
 
 result = getHoleBodyAtCursor()
 if result is None:
-    sendCommand('Cmd_compute_toplevel %s "%s"' % (vim.eval('a:unfoldAbstract'), escape(promptUser("Enter expression: "))))
+    sendCommand('Cmd_compute_toplevel %s "%s"' % (unfoldAbstract, escape(promptUser("Enter expression: "))))
 elif result[1] is None:
     print("Goal not loaded")
 else:
-    sendCommand('Cmd_compute %s %d noRange "%s"' % (vim.eval('a:unfoldAbstract'), result[1], escape(result[0])))
+    sendCommand('Cmd_compute %s %d noRange "%s"' % (unfoldAbstract, result[1], escape(result[0])))
 EOF
 endfunction
 

--- a/ftplugin/agda.vim
+++ b/ftplugin/agda.vim
@@ -207,10 +207,10 @@ def parseVersion(versionString):
     global agdaVersion
     agdaVersion = [int(c) for c in versionString[12:].split('.')]
 
-def compareVersion(versionList, compare):
-    versionNum = int(''.join(map(str,versionList)))
-    agdaVersionNum = int(''.join(map(str,agdaVersion)))
-    return compare(versionNum, agdaVersionNum)
+def compareVersion(a, b, compare):
+    padA = max(0, len(a) - len(b))
+    padB = max(0, len(b) - len(a))
+    return compare((a + [0]*padA), b + [0]*padB)
 
 def interpretResponse(responses, quiet = False):
     for response in responses:
@@ -422,7 +422,7 @@ import operator
 
 unfoldAbstract = vim.eval("a:unfoldAbstract")
 
-if compareVersion([2,5,2,0], operator.lt):
+if compareVersion([2,5,2,0], agdaVersion, operator.lt):
     unfoldAbstract = str(unfoldAbstract == "DefaultCompute")
 
 result = getHoleBodyAtCursor()


### PR DESCRIPTION
My python runtime was unable to identify the `unfoldAbstract` variable since it is a vim function argument (I don't know if its the same case with you).

Also, using array comparison to compare versions seems to break down when the arrays are not of equal length.
eg.
`[2,5,2] < [2,5,2,0]` is true rather than false