### PR TITLE
Fix version check for Cmd_give

### DIFF
--- a/ftplugin/agda.vim
+++ b/ftplugin/agda.vim
@@ -365,7 +365,7 @@ import operator
 
 result = getHoleBodyAtCursor()
 
-if compareVersion([2,5,3,0], agdaVersion, operator.lt):
+if compareVersion(agdaVersion, [2,5,3,0], operator.lt):
     useForce = ""
 else:
     useForce = "WithoutForce" # or WithForce


### PR DESCRIPTION
The _new_ behaviour requires the `WithoutForce` argument.