### PR TITLE
Add support for Cmd_helper_function

### DIFF
--- a/ftplugin/agda.vim
+++ b/ftplugin/agda.vim
@@ -210,7 +210,7 @@ def parseVersion(versionString):
 
 def interpretResponse(responses, quiet = False):
     for response in responses:
-        if response.startswith('(agda2-info-action '):
+        if response.startswith('(agda2-info-action ') or response.startswith('(agda2-info-action-and-copy '):
             if quiet and '*Error*' in response: vim.command('cwindow')
             strings = re.findall(r'"((?:[^"\\]|\\.)*)"', response[19:])
             if strings[0] == '*Agda Version*':
@@ -505,6 +505,23 @@ else:
 EOF
 endfunction
 
+function! HelperFunction()
+exec s:python_until_eof
+import vim
+
+result = getHoleBodyAtCursor()
+
+if result is None:
+    print("No hole under the cursor")
+elif result[1] is None:
+    print("Goal not loaded")
+elif result[0] == "?":
+    sendCommand('Cmd_helper_function %s %d noRange "%s"' % (rewriteMode, result[1], escape(promptUser("Enter name for helper function: "))))
+else:
+    sendCommand('Cmd_helper_function %s %d noRange "%s"' % (rewriteMode, result[1], escape(result[0])))
+EOF
+endfunction
+
 command! -nargs=0 Load call Load(0)
 command! -nargs=0 AgdaVersion call AgdaVersion(0)
 command! -nargs=0 Reload silent! make!|redraw!
@@ -531,6 +548,7 @@ nnoremap <buffer> <LocalLeader>n :call Normalize("IgnoreAbstract")<CR>
 nnoremap <buffer> <LocalLeader>N :call Normalize("DefaultCompute")<CR>
 nnoremap <buffer> <LocalLeader>M :call ShowModule('')<CR>
 nnoremap <buffer> <LocalLeader>y :call WhyInScope('')<CR>
+nnoremap <buffer> <LocalLeader>h :call HelperFunction()<CR>
 nnoremap <buffer> <LocalLeader>m :Metas<CR>
 
 " Show/reload metas


### PR DESCRIPTION
Displays the type signature of helper function. The feature is mapped to `<LocalLeader>h`.

There is a [related commit in my repo](https://github.com/andrejtokarcik/agda-vim/commit/0e838c69e25aef717a11b074ee921d0c45daacfa) that automatically yanks the signature into a specific register and allows the user to paste it immediately using `<LocalLeader>p`. I may add it to this pull request if you'd like.

FWIW, the feature (as present in Emacs mode) can be seen in action [in this lecture](https://www.youtube.com/watch?v=RCRddhYegzI&t=35m20s).