### PR TITLE
Set additional filetype options

### DIFF
--- a/ftplugin/agda.vim
+++ b/ftplugin/agda.vim
@@ -1,3 +1,7 @@
+setlocal iskeyword=33-126,192-255
+setlocal commentstring=--\ %s
+setlocal comments=s1fl:{-,mb:\ \ ,ex:-},:--
+
 " The ReloadSyntax function is reproduced from
 " http://wiki.portal.chalmers.se/agda/pmwiki.php?n=Main.VIMEditing
 " the remainder is covered by the license described in LICENSE.


### PR DESCRIPTION
Defining `setlocal`s that allow easy manipulation of keywords (e.g. by the star command) and comments (e.g. by the vim-commentary plugin).