### PR TITLE
Introduce SetRewriteMode<name> command for each mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ The commands and mappings as defined currently are below:
     command! -nargs=1 ShowModule call ShowModule(<args>)
     command! -nargs=1 WhyInScope call WhyInScope(<args>)
     command! -nargs=1 SetRewriteMode exec s:python_cmd "setRewriteMode('<args>')"
+    command! -nargs=0 SetRewriteModeAsIs exec s:python_cmd "setRewriteMode('AsIs')"
+    command! -nargs=0 SetRewriteModeNormalised exec s:python_cmd "setRewriteMode('Normalised')"
+    command! -nargs=0 SetRewriteModeSimplified exec s:python_cmd "setRewriteMode('Simplified')"
+    command! -nargs=0 SetRewriteModeHeadNormal exec s:python_cmd "setRewriteMode('HeadNormal')"
+    command! -nargs=0 SetRewriteModeInstantiated exec s:python_cmd "setRewriteMode('Instantiated')"
 
     nnoremap <buffer> <LocalLeader>l :Reload<CR>
     nnoremap <buffer> <LocalLeader>t :call Infer()<CR>

--- a/ftplugin/agda.vim
+++ b/ftplugin/agda.vim
@@ -535,6 +535,11 @@ command! -nargs=0 SolveAll exec s:python_cmd "sendCommand('Cmd_solveAll')"
 command! -nargs=1 ShowModule call ShowModule(<args>)
 command! -nargs=1 WhyInScope call WhyInScope(<args>)
 command! -nargs=1 SetRewriteMode exec s:python_cmd "setRewriteMode('<args>')"
+command! -nargs=0 SetRewriteModeAsIs exec s:python_cmd "setRewriteMode('AsIs')"
+command! -nargs=0 SetRewriteModeNormalised exec s:python_cmd "setRewriteMode('Normalised')"
+command! -nargs=0 SetRewriteModeSimplified exec s:python_cmd "setRewriteMode('Simplified')"
+command! -nargs=0 SetRewriteModeHeadNormal exec s:python_cmd "setRewriteMode('HeadNormal')"
+command! -nargs=0 SetRewriteModeInstantiated exec s:python_cmd "setRewriteMode('Instantiated')"
 
 nnoremap <buffer> <LocalLeader>l :Reload<CR>
 nnoremap <buffer> <LocalLeader>t :call Infer()<CR>


### PR DESCRIPTION
It would be helpful to have auto-completion available when switching between the rewrite modes. Since there is only five of them, each mode can be associated with its own `SetRewriteMode<name>` command.

The old command `SetRewriteMode` requiring a parameter (which can also be used to reset the mode back to the default value) remains unchanged.