### PR TITLE
Cmd_auto renamed to Cmd_autoOne in 2.6.0

### DIFF
--- a/ftplugin/agda.vim
+++ b/ftplugin/agda.vim
@@ -413,7 +413,10 @@ if result is None:
 elif result[1] is None:
     print("Goal not loaded")
 else:
-    sendCommand('Cmd_auto %d noRange "%s"' % (result[1], escape(result[0]) if result[0] != "?" else ""))
+    if agdaVersion < [2,6,0,0]:
+        sendCommand('Cmd_auto %d noRange "%s"' % (result[1], escape(result[0]) if result[0] != "?" else ""))
+    else:
+        sendCommand('Cmd_autoOne %d noRange "%s"' % (result[1], escape(result[0]) if result[0] != "?" else ""))
 EOF
 endfunction
 


### PR DESCRIPTION
Fixes auto for the development version of Agda (and so for the upcoming Agda 2.6.0). The change was in https://github.com/agda/agda/commit/133d462c99e4ed9a587e9567103cf44c1137e698, which is also tagged in v2.5.4 onwards, but I have not tested these, and so left it at 2.6.0.