### PR TITLE
Fixed go to definition to work with Agda 2.6+, improved unicode support, added support for python 3

### DIFF
--- a/ftplugin/agda.vim
+++ b/ftplugin/agda.vim
@@ -148,26 +148,18 @@ setlocal matchpairs+=｟:｠
 setlocal matchpairs+=｢:｣
 let b:undo_ftplugin .= ' | setlocal matchpairs<'
 
-" Python 3 is NOT supported.  This code and other changes are left here to
-" ease adding future Python 3 support.  Right now the main issue is that
-" Python 3 treats strings are sequences of characters rather than sequences of
-" bytes which interacts poorly with the fact that the column offsets vim
-" returns are byte offsets in the current line.  The code below should run
-" under Python 3, but it won't match up the holes correctly if you have
-" Unicode characters.
 function! s:UsingPython2()
+  if has('python3')
+    return 0
+  endif
   return 1
-  "if has('python')
-  "  return 1
-  "endif
-  "return 0
 endfunction
 
 let s:using_python2 = s:UsingPython2()
 let s:python_cmd = s:using_python2 ? 'py ' : 'py3 '
 let s:python_loadfile = s:using_python2 ? 'pyfile ' : 'py3file '
 
-if has('python') " || has('python3')
+if has('python') || has('python3')
 
 function! s:LogAgda(name, text, append)
     let agdawinnr = bufwinnr('__Agda__')


### PR DESCRIPTION
### Go to definition

* Fixed regex for parsing annotations to match up with the formatting described in the link above `parseAnnotation`
* Changed highlighting level for load commands sent to Agda process to "Interactive" so that Agda 2.6+ will provide annotation information.

### Improved unicode support, added support for python 3

* Used vimscript more heavily to get better consistency with handling unicode characters fixing errors finding goals when unicode characters appear in the line before the goal
* Switched to unicode strings by default ala python 3 to fix encode/decode errors that occurred when operating on goal bodies that contained unicode characters
* Fixed use of field names only present in python 2 and not 3 and modified the function exposer to call the vim python command associated with the version of python running the script
* Changed the behavior of the vim script to use python 3 if possible and use python 2 as a fallback.