### PR TITLE
Fix the Typerror by decoding the include paths

### DIFF
--- a/agda.py
+++ b/agda.py
@@ -282,9 +282,11 @@ def sendCommandLoadHighlightInfo(file, quiet):
 def sendCommandLoad(file, quiet, highlighting = None):
     global agdaVersion
     if agdaVersion < [2,5,0,0]: # in 2.5 they changed it so Cmd_load takes commandline arguments
-        incpaths_str = ",".join(vim.vars['agdavim_agda_includepathlist'])
+        # vim.vars returns bytes, so we have to decode them before joining
+        incpaths_str = ",".join(list(map(lambda x : x.decode(), vim.vars['agdavim_agda_includepathlist'])))
     else:
-        incpaths_str = "\"-i\"," + ",\"-i\",".join(vim.vars['agdavim_agda_includepathlist'])
+        # vim.vars returns bytes, so we have to decode them before joining
+        incpaths_str = "\"-i\"," + ",\"-i\",".join(list(map(lambda x : x.decode(), vim.vars['agdavim_agda_includepathlist'])))
     if highlighting is None:
         highlighting = vim.vars['agdavim_enable_goto_definition']
     sendCommand('Cmd_load "%s" [%s]' % (escape(file), incpaths_str), quiet = quiet, highlighting = highlighting)

--- a/ftplugin/agda.vim
+++ b/ftplugin/agda.vim
@@ -148,26 +148,18 @@ setlocal matchpairs+=｟:｠
 setlocal matchpairs+=｢:｣
 let b:undo_ftplugin .= ' | setlocal matchpairs<'
 
-" Python 3 is NOT supported.  This code and other changes are left here to
-" ease adding future Python 3 support.  Right now the main issue is that
-" Python 3 treats strings are sequences of characters rather than sequences of
-" bytes which interacts poorly with the fact that the column offsets vim
-" returns are byte offsets in the current line.  The code below should run
-" under Python 3, but it won't match up the holes correctly if you have
-" Unicode characters.
 function! s:UsingPython2()
+  if has('python3')
+    return 0
+  endif
   return 1
-  "if has('python')
-  "  return 1
-  "endif
-  "return 0
 endfunction
 
 let s:using_python2 = s:UsingPython2()
 let s:python_cmd = s:using_python2 ? 'py ' : 'py3 '
 let s:python_loadfile = s:using_python2 ? 'pyfile ' : 'py3file '
 
-if has('python') " || has('python3')
+if has('python') || has('python3')
 
 function! s:LogAgda(name, text, append)
     let agdawinnr = bufwinnr('__Agda__')


### PR DESCRIPTION
Using `"\"-i\"," + ",\"-i\",".join(vim.vars['agdavim_agda_includepathlist'])` to create the command for searching in the extra include paths was causing `TypeError: sequence item 0: expected str instance, bytes found`, because `vim.vars` returns a `bytes` object. This was preventing agda-vim, the python3 one by 1000000000, from working properly for me (I was getting "Goal not loaded" for everything i tried). I fixed it by mapping `lambda x : x.decode()` over the result of `vim.vars`, and it seems to work fine now. I've read somewhere that this might raise an Exception in the case the bytes aren't proper utf-8 byte sequences, so maybe some sort of handling should be added. This is my first pull request ever, so, sorry if i made any dumb mistakes.